### PR TITLE
Eagerly commit alter table statement if new columns are added

### DIFF
--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -91,8 +91,7 @@
             default null;
         {% endfor -%}
 
-
-        {-% if columns_to_create|length > 0 %}
+        {%- if columns_to_create|length > 0 %}
             commit;
         {% endif -%}
 

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -91,6 +91,11 @@
             default null;
         {% endfor -%}
 
+
+        {-% if columns_to_create|length > 0 %}
+            commit;
+        {% endif -%}
+
     {%- else -%}
         create table if not exists {{ audit_table }}
         (


### PR DESCRIPTION
I observed the update table statements not working on a production redshift cluster without this `commit` statement being added:

```
Database Error in model test_table (models/marts/data_engineering/test_table.sql)
  Could not find parent table for alias "analytics.analytics.test_table".
  compiled SQL at target/run/signal_dbt/marts/data_engineering/test_table.sql
```

I'm not sure why this worked in the context of the integration tests in this case, any ideas?