### PR TITLE
Commit log events

### DIFF
--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -42,7 +42,9 @@
         {% if variable != None %}'{{ target_name }}'{% else %}null::varchar(512){% endif %},
         {% if variable != None %}{% if is_full_refresh %}TRUE{% else %}FALSE{% endif %}{% else %}null::boolean{% endif %},
         '{{ invocation_id }}'
-    )
+    );
+    
+    commit;
 
 {% endmacro %}
 
@@ -113,7 +115,7 @@
 
 
 {% macro log_run_end_event() %}
-    {{ logging.log_audit_event('run completed', user=target.user, target_name=target.name, is_full_refresh=flags.FULL_REFRESH) }}; commit;
+    {{ logging.log_audit_event('run completed', user=target.user, target_name=target.name, is_full_refresh=flags.FULL_REFRESH) }}
 {% endmacro %}
 
 


### PR DESCRIPTION
Resolves 'run started' events not being saved to the database except for when the table is created.

See https://github.com/fishtown-analytics/dbt-event-logging/issues/19 for discussion/investigation.

This doesn't seem like it should be necessary based on the change which caused this regression but I haven't been able to piece together another way of getting the run start log to stick.

Closes https://github.com/fishtown-analytics/dbt-event-logging/issues/19