### PR TITLE
Allow customisation of audit schema in base project

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > this package, especially as a post-hook. Please consider if this package is
 > appropriate for your use case before using it.
 
-Requires dbt >= 0.14.0
+Requires dbt >= 0.16.0
 
 This package provides out-of-the-box functionality to log events for all dbt
 invocations, including run start, run end, model start, and model end. It
@@ -31,6 +31,21 @@ models:
 
 That's it! You'll now have a stream of events for all dbt invocations in your
 warehouse.
+
+#### Customising audit schema
+
+It's possible to customise the audit schema for any project by adding a macro named: `get_audit_schema` into your DBT project.
+
+For example to always log into a specific schema, say `analytics_meta`, regardless of DBT schema, you can include the following in your project:
+
+```sql
+-- your_dbt_project/macros/get_audit_schema.sql
+{% macro get_audit_schema() %}
+
+   {{ return('analytics_meta') }}
+
+{% endmacro %}
+```
 
 ### Adapter support
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -7,7 +7,7 @@ test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]
 
-require-dbt-version: ">=0.14.0"
+require-dbt-version: ">=0.16.0"
 
 target-path: "target"
 clean-targets:

--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -1,6 +1,11 @@
 {% macro get_audit_schema() %}
 
-    {{ return(target.schema~'_meta') }}
+    {# if the get_audit_schema macro exists in the base project use that #}
+    {% if context.get(project_name, {}).get('get_audit_schema') %}
+        {{ return(context[project_name].get_audit_schema()) }}
+    {% else %}
+        {{ return(target.schema~'_meta') }}
+    {% endif %}
 
 {% endmacro %}
 


### PR DESCRIPTION
@Limess I opened this up here as I had to make some changes to fix some broken tests, and then had to rebase those changes here.

From PR #22:
----
Use the consumers project `get_audit_schema` macro if one is defined.

This allows the customisation of event logging destination, for example to log to the same table across all dbt runs, or just renaming the table.

This could potentially also be a variable rather than a macro but that's more limited.

This is based on a [suggestion by @clrcrl](https://github.com/fishtown-analytics/dbt-event-logging/issues/21#issuecomment-598177110) and I think it requires a version requirement bump to `0.16.0` because of this.

I've tested this in our own project with a none-existent schema and an existing schema and it works as expected (assuming permissions are setup on existing schemas).

Closes https://github.com/fishtown-analytics/dbt-event-logging/issues/21

#### Caveats

There are some complexities around handling permissions _if this is used to log to a single audit schema_ - grants must be setup in the consuming project to allow usage on the schema and SELECT/INSERT appropriately. This is a bit different to normal DBT grant workflows as the owner needs to do the granting and it's not guaranteed that your current target user has created the table. We're using this macro to check this:

```sql

{% macro owns_audit_schema() %}

  {%- set owns_audit_schema -%}
      SELECT
        pg_namespace.nspname AS table_schema,
        pg_user.usename as user_name
      FROM
        pg_catalog.pg_namespace
        INNER JOIN pg_catalog.pg_user ON pg_user.usesysid = pg_namespace.nspowner AND pg_user.usename = '{{ target.user }}'
      WHERE table_schema = '{{ logging.get_audit_schema() }}'
        AND pg_user.usename = '{{ target.user }}'
    {%- endset -%}

    {%- set result = run_query(owns_audit_schema) -%}

    {%- if execute -%}

      {{ return(result.columns[0].values()|length == 1) }}

    {%- endif -%}

{% endmacro %}

```
