### PR TITLE
Place upper limit on logging package for 0.16.x compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             . venv/bin/activate
 
             pip install --upgrade pip setuptools
-            pip install dbt
+            pip install dbt==0.16.1
 
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: fishtown-analytics/dbt_utils
-   version: '>=0.2.4'
+   version: [">=0.2.4", "<0.4.0"]


### PR DESCRIPTION
If you are currently:
- Using dbt 0.16.x
- Using this package

dbt will install the newest version of utils which requires 0.17.x.

This patch will limit that back to the previous release