### PR TITLE
New env vars for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,6 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          run: setup_creds
-          command: |
-            echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
-
       - restore_cache:
           key: deps1-{{ .Branch }}
 
@@ -33,10 +28,11 @@ jobs:
       - run:
           name: "Run Tests - Postgres"
           environment:
-            CI_DBT_USER: root
-            CI_DBT_PASS: ''
-            CI_DBT_PORT: 5432
-            CI_DBT_DBNAME: circle_test
+            POSTGRES_TEST_HOST: localhost
+            POSTGRES_TEST_USER: root
+            POSTGRES_TEST_PASS: ''
+            POSTGRES_TEST_PORT: 5432
+            POSTGRES_TEST_DBNAME: circle_test
           command: |
             . venv/bin/activate
             cd integration_tests

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -1,5 +1,5 @@
 
-# HEY! This file is used in the dbt-utils integrations tests with CircleCI.
+# HEY! This file is used in the dbt-event-logging integrations tests with CircleCI.
 # You should __NEVER__ check credentials into version control. Thanks for reading :)
 
 config:
@@ -11,31 +11,31 @@ integration_tests:
   outputs:
     postgres:
       type: postgres
-      host: localhost
-      user: "{{ env_var('CI_DBT_USER') }}"
-      pass: "{{ env_var('CI_DBT_PASS') }}"
-      port: "{{ env_var('CI_DBT_PORT') }}"
-      dbname: "{{ env_var('CI_DBT_DBNAME') }}"
+      host: "{{ env_var('POSTGRES_TEST_HOST') }}"
+      user: "{{ env_var('POSTGRES_TEST_USER') }}"
+      pass: "{{ env_var('POSTGRES_TEST_PASS') }}"
+      port: "{{ env_var('POSTGRES_TEST_PORT') }}"
+      dbname: "{{ env_var('POSTGRES_TEST_DBNAME') }}"
       schema: event_logging_integration_tests_postgres
       threads: 1
 
     redshift:
       type: redshift
-      host: "{{ env_var('CI_REDSHIFT_DBT_HOST') }}"
-      user: "{{ env_var('CI_REDSHIFT_DBT_USER') }}"
-      pass: "{{ env_var('CI_REDSHIFT_DBT_PASS') }}"
-      dbname: "{{ env_var('CI_REDSHIFT_DBT_DBNAME') }}"
-      port: 5439
+      host: "{{ env_var('REDSHIFT_TEST_HOST') }}"
+      user: "{{ env_var('REDSHIFT_TEST_USER') }}"
+      pass: "{{ env_var('REDSHIFT_TEST_PASS') }}"
+      dbname: "{{ env_var('REDSHIFT_TEST_DBNAME') }}"
+      port: "{{ env_var('REDSHIFT_TEST_PORT') }}"
       schema: event_logging_integration_tests_redshift
       threads: 1
-
+      
     snowflake:
       type: snowflake
-      account: "{{ env_var('CI_SNOWFLAKE_DBT_ACCOUNT') }}"
-      user: "{{ env_var('CI_SNOWFLAKE_DBT_USER') }}"
-      password: "{{ env_var('CI_SNOWFLAKE_DBT_PASS') }}"
-      role: "{{ env_var('CI_SNOWFLAKE_DBT_ROLE') }}"
-      database: "{{ env_var('CI_SNOWFLAKE_DBT_DATABASE') }}"
-      warehouse: "{{ env_var('CI_SNOWFLAKE_DBT_WAREHOUSE') }}"
+      account: "{{ env_var('SNOWFLAKE_TEST_ACCOUNT') }}"
+      user: "{{ env_var('SNOWFLAKE_TEST_USER') }}"
+      password: "{{ env_var('SNOWFLAKE_TEST_PASSWORD') }}"
+      role: "{{ env_var('SNOWFLAKE_TEST_ROLE') }}"
+      database: "{{ env_var('SNOWFLAKE_TEST_DATABASE') }}"
+      warehouse: "{{ env_var('SNOWFLAKE_TEST_WAREHOUSE') }}"
       schema: event_logging_integration_tests_snowflake
       threads: 1


### PR DESCRIPTION
* Connect to sandboxed, cost-controlled instances of Redshift, Snowflake, BigQuery
* Use same env var nomenclature that dbt uses for its integration tests