### PR TITLE
Add missing space before "Contributing" header in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ New columns were added in v0.2.0:
 
 These will be added to your existing audit table automatically in the `on-run-start` DBT hook, and added to the staging tables deployed by this table when they are ran. The existing `event_schema` column will also be propagated into to `stg_dbt_model_deployments` as `schema`.
 
-###Contributing
+### Contributing
 Additional contributions to this repo are very welcome! Check out [this](https://discourse.getdbt.com/t/contributing-to-an-external-dbt-package/657) post on the best workflow for contributing to a package. All PRs should only include functionality that is contained within all Segment deployments; no implementation-specific details should be included.


### PR DESCRIPTION
**Problem**
Missing a space so it doesn't show up as a header in Markdown

![image](https://user-images.githubusercontent.com/9021054/86613044-e3a40200-bf65-11ea-8ea7-670d1d5513c8.png)
