### PR TITLE
Fix tests

### DIFF
--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -14,7 +14,7 @@ integration_tests:
       host: "{{ env_var('POSTGRES_TEST_HOST') }}"
       user: "{{ env_var('POSTGRES_TEST_USER') }}"
       pass: "{{ env_var('POSTGRES_TEST_PASS') }}"
-      port: "{{ env_var('POSTGRES_TEST_PORT') }}"
+      port: "{{ env_var('POSTGRES_TEST_PORT') | as_number }}"
       dbname: "{{ env_var('POSTGRES_TEST_DBNAME') }}"
       schema: event_logging_integration_tests_postgres
       threads: 1
@@ -25,10 +25,10 @@ integration_tests:
       user: "{{ env_var('REDSHIFT_TEST_USER') }}"
       pass: "{{ env_var('REDSHIFT_TEST_PASS') }}"
       dbname: "{{ env_var('REDSHIFT_TEST_DBNAME') }}"
-      port: "{{ env_var('REDSHIFT_TEST_PORT') }}"
+      port: "{{ env_var('REDSHIFT_TEST_PORT') | as_number }}"
       schema: event_logging_integration_tests_redshift
       threads: 1
-      
+
     snowflake:
       type: snowflake
       account: "{{ env_var('SNOWFLAKE_TEST_ACCOUNT') }}"


### PR DESCRIPTION
@jtcohen6 — the tests on this started failing because of the 0.17.1 changes (see [this PR](https://github.com/fishtown-analytics/dbt-event-logging/pull/32)). Given that the changes are in the integration tests, I don't feel that a release that includes this code would be a breaking change.

Should we also take this opportunity to update the `pip install dbt` step to include the version number?