### PR TITLE
Query INFORMATION SCHEMA before running CREATE IF NOT EXISTS

### DIFF
--- a/macros/audit.sql
+++ b/macros/audit.sql
@@ -62,10 +62,14 @@
 
 
 {% macro create_audit_schema() %}
-    {% do create_schema(api.Relation.create(
-        database=target.database,
-        schema=logging.get_audit_schema())
-    ) %}
+    {%- set schema_name = logging.get_audit_schema() -%}
+    {%- set schema_exists = adapter.check_schema_exists(database=target.database, schema=schema_name) -%}
+    {% if schema_exists == 0 %}
+        {% do create_schema(api.Relation.create(
+            database=target.database,
+            schema=schema_name)
+        ) %}
+    {% endif %}
 {% endmacro %}
 
 


### PR DESCRIPTION
## Description & motivation
Running CREATE IF NOT EXISTS still requires CREATE SCHEMA privileges, at least in Snowflake. We can work around it by looking up if meta schema exists in INFORMATION SCHEMA.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
