### PR TITLE
Updating dependencies versions for dbt-labs/dbt_utils 

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: dbt-labs/dbt_utils
-   version: [">=0.8.0", "<0.9.0"]
+   version: [">=0.8.0", "<1.0.0"]


### PR DESCRIPTION
## Description & motivation
<!---

-->
Version dependency on dbt-labs/dbt_utils doesn't allow for `dbt deps` install. Related to issue [51](https://github.com/dbt-labs/dbt-event-logging/issues/51)

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
